### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ conda install pytorch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 cpuonly -c py
 ```
 pip install resemble-enhance
 pip install -r requirements.txt
-pip install WeTextProcessing
+pip install WeTextProcessing==1.0.0
 ```
 ```
 python webui/webui.py


### PR DESCRIPTION
WeTextProcessing版本需要锁定为1.0.0，因为最新版存在fst兼容性问题。