### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ scipy==1.13.1
 soundfile==0.12.1
 resampy==0.4.2
 tabulate==0.8.10
-gradio==4.32.2
+gradio
 jieba==0.42.1
 srt==3.5.3
 pypinyin==0.51.0


### PR DESCRIPTION
锁定的gradio版本与未锁定的fastapi、pydantic版本不兼容。鉴于最新版本gradio可以解决问题，而旧版本fastapi和pydantic未知，那就考虑解除锁定吧？